### PR TITLE
Absorb SSID into callsign to accomodate unconventional IDs

### DIFF
--- a/core/src/callsign.rs
+++ b/core/src/callsign.rs
@@ -7,27 +7,17 @@ use crate::AprsError;
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize)]
 #[serde(into = "String")]
-pub struct Callsign {
-    pub call: String,
-    pub ssid: Option<u8>,
-}
+pub struct Callsign(pub String);
 
 impl From<Callsign> for String {
     fn from(val: Callsign) -> Self {
-        if let Some(ssid) = val.ssid {
-            format!("{}-{}", val.call, ssid)
-        } else {
-            val.call
-        }
+        val.0
     }
 }
 
 impl Callsign {
-    pub fn new<T: Into<String>>(call: T, ssid: Option<u8>) -> Callsign {
-        Callsign {
-            call: call.into(),
-            ssid,
-        }
+    pub fn new<T: Into<String>>(call: T) -> Callsign {
+        Callsign(call.into())
     }
 }
 
@@ -35,42 +25,16 @@ impl FromStr for Callsign {
     type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
-        let delimiter = s.find('-'); //.ok_or_else(|| AprsError::EmptyCallsign(s.to_owned()))?;
-        if delimiter.is_none() {
-            return Ok(Callsign::new(s, None));
-        }
-
-        let delimiter = delimiter.unwrap();
-        if delimiter == 0 {
+        if s.is_empty() {
             return Err(AprsError::EmptyCallsign(s.to_owned()));
         }
-
-        let (call, rest) = s.split_at(delimiter);
-        let part = &rest[1..rest.len()];
-
-        if part.is_empty() {
-            return Err(AprsError::EmptySSID(s.to_owned()));
-        }
-
-        let ssid = part.parse::<u8>().ok();
-
-        if ssid.is_some() {
-            Ok(Callsign::new(call, ssid))
-        } else {
-            Err(AprsError::InvalidSSID(s.to_owned()))
-        }
+        Ok(Callsign::new(s))
     }
 }
 
 impl Display for Callsign {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", self.call)?;
-
-        if let Some(ssid) = &self.ssid {
-            write!(f, "-{ssid}")?;
-        }
-
-        Ok(())
+        write!(f, "{}", self.0)
     }
 }
 
@@ -80,35 +44,24 @@ mod tests {
 
     #[test]
     fn parse_callsign() {
-        assert_eq!("ABCDEF".parse(), Ok(Callsign::new("ABCDEF", None)));
+        assert_eq!("ABCDEF".parse(), Ok(Callsign::new("ABCDEF")));
     }
 
     #[test]
     fn parse_with_ssid() {
-        assert_eq!("ABCDEF-42".parse(), Ok(Callsign::new("ABCDEF", Some(42))));
+        assert_eq!("ABCDEF-42".parse(), Ok(Callsign::new("ABCDEF-42")));
     }
 
     #[test]
     fn empty_callsign() {
         assert_eq!(
-            "-42".parse::<Callsign>(),
-            Err(AprsError::EmptyCallsign("-42".to_owned()))
+            "".parse::<Callsign>(),
+            Err(AprsError::EmptyCallsign("".to_owned()))
         );
     }
 
     #[test]
-    fn empty_ssid() {
-        assert_eq!(
-            "ABCDEF-".parse::<Callsign>(),
-            Err(AprsError::EmptySSID("ABCDEF-".to_owned()))
-        );
-    }
-
-    #[test]
-    fn invalid_ssid() {
-        assert_eq!(
-            "D-EKDF".parse::<Callsign>(),
-            Err(AprsError::InvalidSSID("D-EKDF".to_owned()))
-        );
+    fn parse_callsign_with_dash() {
+        assert_eq!("D-EKDF".parse(), Ok(Callsign::new("D-EKDF")));
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -4,10 +4,6 @@ use serde::Serialize;
 pub enum AprsError {
     #[error("Empty Callsign: {0}")]
     EmptyCallsign(String),
-    #[error("Empty Callsign SSID: {0}")]
-    EmptySSID(String),
-    #[error("Invalid Callsign SSID: {0}")]
-    InvalidSSID(String),
     #[error("Invalid Timestamp: {0}")]
     InvalidTimestamp(String),
     #[error("Unsupported Position Format: {0}")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,23 +17,11 @@
 //!
 //!     // Ok(
 //!     //     AprsPacket {
-//!     //         from: Callsign {
-//!     //             call: "ICA3D17F2",
-//!     //             ssid: None
-//!     //         },
-//!     //         to: Callsign {
-//!     //             call: "APRS",
-//!     //             ssid: None
-//!     //         },
+//!     //         from: Callsign("ICA3D17F2"),
+//!     //         to: Callsign("APRS"),
 //!     //         via: [
-//!     //             Callsign {
-//!     //                 call: "qAS",
-//!     //                 ssid: None
-//!     //             },
-//!     //             Callsign {
-//!     //                 call: "dl4mea",
-//!     //                 ssid: None
-//!     //             }
+//!     //             Callsign("qAS"),
+//!     //             Callsign("dl4mea")
 //!     //         ],
 //!     //         data: Position(
 //!     //             AprsPosition {

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -124,11 +124,11 @@ mod tests {
     #[test]
     fn parse() {
         let result = r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 !W46! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1".parse::<AprsPacket>().unwrap();
-        assert_eq!(result.from, Callsign::new("ICA3D17F2", None));
-        assert_eq!(result.to, Callsign::new("APRS", None));
+        assert_eq!(result.from, Callsign::new("ICA3D17F2"));
+        assert_eq!(result.to, Callsign::new("APRS"));
         assert_eq!(
             result.via,
-            vec![Callsign::new("qAS", None), Callsign::new("dl4mea", None),]
+            vec![Callsign::new("qAS"), Callsign::new("dl4mea"),]
         );
 
         match result.data {
@@ -150,7 +150,7 @@ mod tests {
         let result =
             r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 Hochkönig"
                 .parse::<AprsPacket>();
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -159,11 +159,11 @@ mod tests {
             r"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {32975"
                 .parse::<AprsPacket>()
                 .unwrap();
-        assert_eq!(result.from, Callsign::new("ICA3D17F2", None));
-        assert_eq!(result.to, Callsign::new("Aprs", None));
+        assert_eq!(result.from, Callsign::new("ICA3D17F2"));
+        assert_eq!(result.to, Callsign::new("Aprs"));
         assert_eq!(
             result.via,
-            vec![Callsign::new("qAS", None), Callsign::new("dl4mea", None),]
+            vec![Callsign::new("qAS"), Callsign::new("dl4mea"),]
         );
 
         match result.data {
@@ -181,11 +181,11 @@ mod tests {
         let result = r"ICA3D17F2>APRS,qAS,dl4mea:>312359zStatus seems okay!"
             .parse::<AprsPacket>()
             .unwrap();
-        assert_eq!(result.from, Callsign::new("ICA3D17F2", None));
-        assert_eq!(result.to, Callsign::new("APRS", None));
+        assert_eq!(result.from, Callsign::new("ICA3D17F2"));
+        assert_eq!(result.to, Callsign::new("APRS"));
         assert_eq!(
             result.via,
-            vec![Callsign::new("qAS", None), Callsign::new("dl4mea", None),]
+            vec![Callsign::new("qAS"), Callsign::new("dl4mea"),]
         );
 
         match result.data {


### PR DESCRIPTION
For example, https://www.gliderradar.com/views/overview.php?id=248243&imperialUnits=0

https://github.com/hut8/ogn-parser-rs/issues/1